### PR TITLE
Downgrade Rust edition from 2024 to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.4.1"
 keywords = ["incremental", "parsing", "lisp"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/theHamsta/tree-sitter-commonlisp"
-edition = "2024"
+edition = "2021"
 authors = ["Stephan Seitz"]
 license = "MIT"
 


### PR DESCRIPTION
To enable Rust programs using an earlier edition to use this crate.

Closes #45.