### PR TITLE
Add highlights.scm for syntax highlighting rules

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,0 +1,26 @@
+;; Literals and Constants
+(str_lit) @string
+(num_lit) @number
+(kwd_lit) @string.special.symbol
+(nil_lit) @constant.builtin
+(sym_lit) @variable
+
+;; Known builtins
+((sym_lit) @keyword
+ (#any-of? @keyword
+   "let" "let*" "if" "when" "unless" "cond" 
+   "handler-bind" "destructuring-bind" 
+   "case" "ecase" "typecase" "progn"))
+(loop_macro "loop" @keyword)
+
+(defun_header
+  keyword: _ @keyword
+  function_name: (sym_lit) @function)
+
+;; Comments
+(comment) @comment
+(dis_expr) @comment
+
+;; Punctuation
+["(" ")"] @punctuation.bracket
+["'" "`" "," ",@"] @punctuation.special


### PR DESCRIPTION
The tree-sitter.json refers to a queries/highlights.scm file which doesn't exist, so I have added one. It's pretty basic, but covers most use-cases.