### PR TITLE
Include license file when packaging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT"
 
 build = "bindings/rust/build.rs"
 include = [
+  "LICENSE.md",
   "bindings/rust/*",
   "grammar.js",
   "queries/*",


### PR DESCRIPTION
This is required by the MIT license terms; discovered when packaging for Fedora

```
$ cargo package --list --allow-dirty | grep LICENSE
LICENSE.md
```